### PR TITLE
Make gained command work properly with inferred username

### DIFF
--- a/src/commands/instances/player/PlayerGained.ts
+++ b/src/commands/instances/player/PlayerGained.ts
@@ -20,7 +20,7 @@ class PlayerGained implements Command {
   }
 
   activated(message: ParsedMessage) {
-    return message.command === 'gained' && message.args.length > 0;
+    return message.command === 'gained';
   }
 
   async execute(message: ParsedMessage) {


### PR DESCRIPTION
Not sure if this behaviour was meant to be like this, but if you have set a username and use the command !gained without any arguments, the default "week" argument didn't trigger. This fixes that.