### PR TITLE
Add ehp ehb

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -64,6 +64,7 @@ export interface GroupHiscoresEntry {
   kills?: number;
   score?: number;
   level?: number;
+  value?: number;
 }
 
 export interface GroupGainedEntry {
@@ -246,6 +247,12 @@ export interface PlayerGains {
       };
       // Defined in activity gains
       score?: {
+        start: number;
+        end: number;
+        gained: number;
+      };
+      // Defined in virtual gains
+      value?: {
         start: number;
         end: number;
         gained: number;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -87,7 +87,8 @@ export interface GroupRecordEntry {
 export enum MetricType {
   Skill = 'Skill',
   Boss = 'Boss',
-  Activity = 'Activity'
+  Activity = 'Activity',
+  Virtual = 'Virtual'
 }
 
 export interface SkillResult {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -9,6 +9,11 @@ export interface Player {
   updatedAt: Date;
   lastImportedAt?: Date;
   latestSnapshot: Snapshot;
+  ttm: number;
+  tt200m: number;
+  ehp: number;
+  ehb: number;
+  exp: number;
 
   // Only in group related lists
   role?: string;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -97,6 +97,7 @@ export interface SkillResult {
   type: MetricType;
   rank: number;
   experience: number;
+  ehp: number;
   level?: number;
 }
 
@@ -105,6 +106,7 @@ export interface BossResult {
   type: MetricType;
   rank: number;
   kills: number;
+  ehb: number;
 }
 
 export interface ActivityResult {

--- a/src/commands/instances/group/GroupHiscores.ts
+++ b/src/commands/instances/group/GroupHiscores.ts
@@ -3,7 +3,15 @@ import { fetchGroupDetails, fetchGroupHiscores } from '../../../api/modules/grou
 import { GroupHiscoresEntry } from '../../../api/types';
 import config from '../../../config';
 import { Command, ParsedMessage } from '../../../types';
-import { getAbbreviation, getEmoji, getMetricName, isBoss, isSkill, toKMB } from '../../../utils';
+import {
+  getAbbreviation,
+  getEmoji,
+  getMetricName,
+  isActivity,
+  isBoss,
+  isSkill,
+  toKMB
+} from '../../../utils';
 import CommandError from '../../CommandError';
 
 class GroupHiscores implements Command {
@@ -58,7 +66,11 @@ class GroupHiscores implements Command {
       return `${toKMB(result.kills || 0)}`;
     }
 
-    return `${toKMB(result.score || 0)}`;
+    if (isActivity(metric)) {
+      return `${toKMB(result.score || 0)}`;
+    }
+
+    return `${result.value || 0}`;
   }
 
   getMetricArg(args: string[]): string {

--- a/src/commands/instances/index.ts
+++ b/src/commands/instances/index.ts
@@ -16,6 +16,7 @@ import PlayerBossesCommand from './player/PlayerBosses';
 import PlayerGainedCommand from './player/PlayerGained';
 import PlayerSetUsername from './player/PlayerSetUsername';
 import PlayerStatsCommand from './player/PlayerStats';
+import PlayerVirtualsCommand from './player/PlayerVirtuals';
 import PlayerUpdateCommand from './player/UpdatePlayer';
 
 const commands: Command[] = [
@@ -29,6 +30,7 @@ const commands: Command[] = [
   PlayerAchievements,
   PlayerUpdateCommand,
   PlayerGainedCommand,
+  PlayerVirtualsCommand,
   PlayerSetUsername,
 
   // group commands

--- a/src/commands/instances/player/PlayerBosses.ts
+++ b/src/commands/instances/player/PlayerBosses.ts
@@ -6,7 +6,7 @@ import { BossResult, MetricType, Player } from '../../../api/types';
 import config from '../../../config';
 import { getUsername } from '../../../database/services/alias';
 import { CanvasAttachment, Command, ParsedMessage, Renderable } from '../../../types';
-import { encodeURL, toKMB } from '../../../utils';
+import { encodeURL, round, toKMB } from '../../../utils';
 import { getScaledCanvas } from '../../../utils/rendering';
 import CommandError from '../../CommandError';
 
@@ -16,7 +16,8 @@ const RENDER_PADDING = 15;
 
 enum RenderVariant {
   Kills = 'Kills',
-  Ranks = 'Ranks'
+  Ranks = 'Ranks',
+  EHB = 'EHB'
 }
 
 class PlayerBosses implements Command, Renderable {
@@ -25,7 +26,7 @@ class PlayerBosses implements Command, Renderable {
 
   constructor() {
     this.name = 'View player bosses';
-    this.template = '!bosses {username} [--ranks]';
+    this.template = '!bosses {username} [--ranks/--ehb]';
   }
 
   activated(message: ParsedMessage) {
@@ -118,6 +119,15 @@ class PlayerBosses implements Command, Renderable {
         // Boss rank
         ctx.fillStyle = isRanked ? '#ffffff' : '#6e6e6e';
         ctx.fillText(rank, originX + 44 - rankWidth / 2, originY + 17);
+      } else if (variant === RenderVariant.EHB) {
+        ctx.font = '10px Arial';
+
+        const ehb = `${round(result.ehb, 1)}`;
+        const ehbWidth = ctx.measureText(ehb).width;
+
+        // Boss EHB
+        ctx.fillStyle = isRanked ? '#ffffff' : '#6e6e6e';
+        ctx.fillText(ehb, originX + 44 - ehbWidth / 2, originY + 17);
       }
     }
 
@@ -152,6 +162,10 @@ class PlayerBosses implements Command, Renderable {
 
     if (variantArg === '--rank' || variantArg === '--ranks') {
       return RenderVariant.Ranks;
+    }
+
+    if (variantArg === '--ehb' || variantArg === '--hours') {
+      return RenderVariant.EHB;
     }
 
     return RenderVariant.Kills;

--- a/src/commands/instances/player/PlayerGained.ts
+++ b/src/commands/instances/player/PlayerGained.ts
@@ -100,6 +100,11 @@ class PlayerGained implements Command {
   buildGainsList(displayName: string, period: string, gained: PlayerGains) {
     const gainedArray = Array.from(Object.entries(gained.data));
 
+    const virtualGains = gainedArray
+      .filter(([, e]) => e.value && e.value.gained > 0)
+      .map(([key, val]) => ({ metric: key, gained: val.value?.gained || 0 }))
+      .sort((a: any, b: any) => b.gained - a.gained);
+
     const skillGains = gainedArray
       .filter(([, e]) => e.experience && e.experience.gained > 0)
       .map(([key, val]) => ({ metric: key, gained: val.experience?.gained || 0 }))
@@ -115,7 +120,7 @@ class PlayerGained implements Command {
       .map(([key, val]) => ({ metric: key, gained: val.score?.gained || 0 }))
       .sort((a: any, b: any) => b.gained - a.gained);
 
-    const valid = [...skillGains, ...bossGains, ...activityGains];
+    const valid = [...virtualGains, ...skillGains, ...bossGains, ...activityGains];
 
     if (!valid || valid.length === 0) {
       throw new Error(`${displayName} has no ${period} gains.`);

--- a/src/commands/instances/player/PlayerStats.ts
+++ b/src/commands/instances/player/PlayerStats.ts
@@ -6,7 +6,7 @@ import { MetricType, Player, SkillResult } from '../../../api/types';
 import config from '../../../config';
 import { getUsername } from '../../../database/services/alias';
 import { CanvasAttachment, Command, ParsedMessage, Renderable } from '../../../types';
-import { encodeURL, SKILLS, toKMB } from '../../../utils';
+import { encodeURL, round, SKILLS, toKMB } from '../../../utils';
 import { getScaledCanvas } from '../../../utils/rendering';
 import CommandError from '../../CommandError';
 
@@ -17,7 +17,8 @@ const RENDER_PADDING = 15;
 enum RenderVariant {
   Levels = 'Levels',
   Ranks = 'Ranks',
-  Experience = 'Experience'
+  Experience = 'Experience',
+  EHP = 'EHP'
 }
 
 class PlayerStats implements Command, Renderable {
@@ -26,7 +27,7 @@ class PlayerStats implements Command, Renderable {
 
   constructor() {
     this.name = 'View player stats';
-    this.template = '!stats {username} [--exp/--ranks]';
+    this.template = '!stats {username} [--exp/--ranks/--ehp]';
   }
 
   activated(message: ParsedMessage) {
@@ -131,6 +132,14 @@ class PlayerStats implements Command, Renderable {
 
         // Skill Rank
         ctx.fillText(rank, originX + 44 - rankWidth / 2, originY + 17);
+      } else if (variant === RenderVariant.EHP) {
+        ctx.font = '9px sans-serif';
+
+        const ehp = `${round(result.ehp || 0, 1)}`;
+        const ehpWidth = ctx.measureText(ehp).width;
+
+        // Skill EHP
+        ctx.fillText(ehp, originX + 44 - ehpWidth / 2, originY + 16);
       }
     }
 
@@ -169,6 +178,10 @@ class PlayerStats implements Command, Renderable {
 
     if (variantArg === '--rank' || variantArg === '--ranks') {
       return RenderVariant.Ranks;
+    }
+
+    if (variantArg === '--ehp' || variantArg === '--hours') {
+      return RenderVariant.EHP;
     }
 
     return RenderVariant.Levels;

--- a/src/commands/instances/player/PlayerStats.ts
+++ b/src/commands/instances/player/PlayerStats.ts
@@ -55,7 +55,7 @@ class PlayerStats implements Command, Renderable {
       const embed = new MessageEmbed()
         .setColor(config.visuals.blue)
         .setURL(encodeURL(`https://wiseoldman.net/players/${player.displayName}`))
-        .setTitle(`${player.displayName} - ${variant}`)
+        .setTitle(`${player.displayName} (Combat ${player.combatLevel}) - ${variant}`)
         .setImage(`attachment://${fileName}`)
         .setFooter('Last updated')
         .setTimestamp(player.updatedAt)

--- a/src/commands/instances/player/PlayerVirtuals.ts
+++ b/src/commands/instances/player/PlayerVirtuals.ts
@@ -1,0 +1,93 @@
+import { MessageEmbed } from 'discord.js';
+import { fetchPlayer } from '../../../api/modules/players';
+import config from '../../../config';
+import { getUsername } from '../../../database/services/alias';
+import { Command, ParsedMessage } from '../../../types';
+import { encodeURL, round, toKMB } from '../../../utils';
+import CommandError from '../../CommandError';
+
+class PlayerVirtuals implements Command {
+  name: string;
+  template: string;
+
+  constructor() {
+    this.name = 'View player virtual stats';
+    this.template = '![virtuals/ttm/ehp/ehb] {username}';
+  }
+
+  activated(message: ParsedMessage) {
+    const cmd = message.command;
+    return cmd === 'virtuals' || cmd === 'ttm' || cmd === 'ehp' || cmd === 'ehb';
+  }
+
+  async execute(message: ParsedMessage) {
+    // Grab the username from the command's arguments or database alias
+    const username = await this.getUsername(message);
+
+    if (!username) {
+      throw new CommandError(
+        'This commands requires a username. Set a default by using the `setrsn` command.'
+      );
+    }
+
+    try {
+      const player = await fetchPlayer(username);
+
+      if (player.ehp === 0 && player.tt200m === 0) {
+        throw new CommandError(`This player is outdated. Please try "!update ${username}" first.`);
+      }
+
+      const embed = new MessageEmbed()
+        .setColor(config.visuals.blue)
+        .setURL(encodeURL(`https://wiseoldman.net/players/${player.displayName}`))
+        .setTitle(`${player.displayName} - Virtual Stats`)
+        .addFields([
+          {
+            name: 'Time To Max',
+            value: player.ttm ? `${round(player.ttm, 2)} hours` : '---'
+          },
+          {
+            name: 'Time To 200m All',
+            value: player.tt200m ? `${round(player.tt200m, 2)} hours` : '---'
+          },
+          {
+            name: 'Efficient Hours Played',
+            value: player.ehp ? round(player.ehp, 2) : '---'
+          },
+          {
+            name: 'Efficient Hours Bosses',
+            value: player.ehb ? round(player.ehb, 2) : '---'
+          },
+          {
+            name: 'Total Experience',
+            value: player.exp ? toKMB(player.exp, 2) : '---'
+          }
+        ])
+        .setFooter('Last updated')
+        .setTimestamp(player.updatedAt);
+
+      message.respond(embed);
+    } catch (e) {
+      if (e instanceof CommandError) throw e;
+
+      const errorMessage = `**${username}** is not being tracked yet.`;
+      const errorTip = `Try !update ${username}`;
+
+      throw new CommandError(errorMessage, errorTip);
+    }
+  }
+
+  async getUsername(message: ParsedMessage): Promise<string | undefined | null> {
+    const explicitUsername = message.args.filter(a => !a.startsWith('--')).join(' ');
+
+    if (explicitUsername) {
+      return explicitUsername;
+    }
+
+    const inferedUsername = await getUsername(message.sourceMessage.author.id);
+
+    return inferedUsername;
+  }
+}
+
+export default new PlayerVirtuals();

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,6 +126,9 @@ export enum Emoji {
   bounty_hunter_rogue = '<:bounty_hunter_rogue:730171196561293392>',
   clue = '<:clue_scrolls_all:729844134004785204>',
 
+  ehp = '<:ehp:766260738221670432>',
+  ehb = '<:ehb:766260773617795103>',
+
   success = '✅',
   error = '❌',
   warning = '⚠️',

--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -88,10 +88,16 @@ const BOSSES_MAP = [
   { key: 'zulrah', name: 'Zulrah' }
 ];
 
+const VIRTUALS_MAP = [
+  { key: 'ehp', name: 'EHP' },
+  { key: 'ehb', name: 'EHB' }
+];
+
 export const SKILLS = SKILLS_MAP.map(s => s.key);
 export const ACTIVITIES = ACTIVITIES_MAP.map(s => s.key);
 export const BOSSES = BOSSES_MAP.map(s => s.key);
-export const ALL_METRICS = [...SKILLS, ...ACTIVITIES, ...BOSSES];
+export const VIRTUALS = VIRTUALS_MAP.map(s => s.key);
+export const ALL_METRICS = [...SKILLS, ...ACTIVITIES, ...BOSSES, ...VIRTUALS];
 
 export function isSkill(metric: string): boolean {
   return SKILLS.includes(metric);
@@ -103,6 +109,10 @@ export function isActivity(metric: string): boolean {
 
 export function isBoss(metric: string): boolean {
   return BOSSES.includes(metric);
+}
+
+export function isVirtual(metric: string): boolean {
+  return VIRTUALS.includes(metric);
 }
 
 export function getType(metric: string): MetricType | null {
@@ -118,6 +128,10 @@ export function getType(metric: string): MetricType | null {
     return MetricType.Boss;
   }
 
+  if (isVirtual(metric)) {
+    return MetricType.Virtual;
+  }
+
   return null;
 }
 
@@ -130,7 +144,11 @@ export function getMeasure(metric: string): string {
     return 'score';
   }
 
-  return 'kills';
+  if (isBoss(metric)) {
+    return 'kills';
+  }
+
+  return 'value';
 }
 
 export function getMetricName(metric: string): string {
@@ -138,7 +156,7 @@ export function getMetricName(metric: string): string {
     return 'Combat';
   }
 
-  const allMetricConfigs = [...SKILLS_MAP, ...ACTIVITIES_MAP, ...BOSSES_MAP];
+  const allMetricConfigs = [...SKILLS_MAP, ...ACTIVITIES_MAP, ...BOSSES_MAP, ...VIRTUALS_MAP];
 
   for (let i = 0; i < allMetricConfigs.length; i += 1) {
     if (allMetricConfigs[i].key === metric) {

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -5,20 +5,20 @@
  * Decimal precision of 2 = 356.69
  */
 export function toKMB(number: number, decimalPrecision = 2): string {
-  function round(number: number): string {
-    const precision = Math.pow(10, decimalPrecision);
-    return (Math.round(number * precision) / precision).toString();
-  }
-
   if (number > 999999999 || number < -999999999) {
-    return round(number / 1000000000) + 'b';
+    return round(number / 1000000000, decimalPrecision) + 'b';
   } else if (number > 999999 || number < -999999) {
-    return round(number / 1000000) + 'm';
+    return round(number / 1000000, decimalPrecision) + 'm';
   } else if (number > 999 || number < -999) {
-    return round(number / 1000) + 'k';
+    return round(number / 1000, decimalPrecision) + 'k';
   } else {
-    return round(number);
+    return round(number, decimalPrecision);
   }
+}
+
+export function round(number: number, cases: number): string {
+  const precision = Math.pow(10, cases);
+  return (Math.round(number * precision) / precision).toString();
 }
 
 export function encodeURL(url: string): string {


### PR DESCRIPTION
- Added EHP and EHB to the metrics list (and emoji list)
- Fix previous commands that didn't recognize EHP/EHB
- Added `--ehp` and `--hours` flags to the  `!stats` command (Ex: `!stats Zezima --ehp`)
- Added `--ehb` and `--hours` flags to the  `!bosses` command (Ex: `!bosses Zezima --ehb`)
- Added a new "player virtual stats command" with 4 different aliases: `!ttm`, `!virtuals`, `!ehp` , `!ehb`
- Added the player's combat level to the title of the `!stats` command