### PR TITLE
Add moderator commands

### DIFF
--- a/src/api/modules/competitions.ts
+++ b/src/api/modules/competitions.ts
@@ -49,3 +49,15 @@ export async function fetchCompetition(id: number): Promise<Competition> {
 
   return data;
 }
+
+/**
+ * Send an API request attempting to reset a competition's verification code.
+ */
+export async function resetCode(competitionId: number): Promise<{ newCode: string }> {
+  const URL = `/competitions/${competitionId}/reset-code`;
+  const adminPassword = process.env.ADMIN_PASSWORD;
+
+  const { data } = await api.put(URL, { adminPassword });
+
+  return data;
+}

--- a/src/api/modules/groups.ts
+++ b/src/api/modules/groups.ts
@@ -111,6 +111,18 @@ async function resetCode(groupId: number): Promise<{ newCode: string }> {
   return data;
 }
 
+/**
+ * Send an API request attempting to verify a group.
+ */
+async function verify(groupId: number): Promise<Group> {
+  const URL = `/groups/${groupId}/verify`;
+  const adminPassword = process.env.ADMIN_PASSWORD;
+
+  const { data } = await api.put(URL, { adminPassword });
+
+  return data;
+}
+
 export {
   fetchGroupDetails,
   fetchGroupMembers,
@@ -118,5 +130,6 @@ export {
   fetchGroupHiscores,
   fetchGroupGained,
   fetchGroupRecords,
-  resetCode
+  resetCode,
+  verify
 };

--- a/src/api/modules/groups.ts
+++ b/src/api/modules/groups.ts
@@ -99,11 +99,24 @@ async function fetchGroupRecords(
   return data;
 }
 
+/**
+ * Send an API request attempting to reset a group's verification code.
+ */
+async function resetCode(groupId: number): Promise<{ newCode: string }> {
+  const URL = `/groups/${groupId}/reset-code`;
+  const adminPassword = process.env.ADMIN_PASSWORD;
+
+  const { data } = await api.put(URL, { adminPassword });
+
+  return data;
+}
+
 export {
   fetchGroupDetails,
   fetchGroupMembers,
   fetchGroupCompetitions,
   fetchGroupHiscores,
   fetchGroupGained,
-  fetchGroupRecords
+  fetchGroupRecords,
+  resetCode
 };

--- a/src/commands/instances/index.ts
+++ b/src/commands/instances/index.ts
@@ -13,6 +13,7 @@ import GroupMembersCommand from './group/GroupMembers';
 import GroupRecordsCommand from './group/GroupRecords';
 import ResetCompetitionCode from './moderation/ResetCompetitionCode';
 import ResetGroupCode from './moderation/ResetGroupCode';
+import VerifyGroup from './moderation/VerifyGroup';
 import PlayerAchievements from './player/PlayerAchievements';
 import PlayerActivitiesCommand from './player/PlayerActivities';
 import PlayerBossesCommand from './player/PlayerBosses';
@@ -30,6 +31,7 @@ const commands: Command[] = [
   // moderation commands
   ResetGroupCode,
   ResetCompetitionCode,
+  VerifyGroup,
 
   // player commands
   PlayerStatsCommand,

--- a/src/commands/instances/index.ts
+++ b/src/commands/instances/index.ts
@@ -1,6 +1,6 @@
 import { Command } from '../../types';
-import ConfigDefaultChannel from './config/ConfigDefaultChannel';
 import ConfigChannelPreference from './config/ConfigChannelPreference';
+import ConfigDefaultChannel from './config/ConfigDefaultChannel';
 import ConfigGroup from './config/ConfigGroup';
 import ConfigPrefix from './config/ConfigPrefix';
 import HelpCommand from './general/Help';
@@ -11,19 +11,25 @@ import GroupGainedCommand from './group/GroupGained';
 import GroupHiscoresCommand from './group/GroupHiscores';
 import GroupMembersCommand from './group/GroupMembers';
 import GroupRecordsCommand from './group/GroupRecords';
+import ResetCompetitionCode from './moderation/ResetCompetitionCode';
+import ResetGroupCode from './moderation/ResetGroupCode';
 import PlayerAchievements from './player/PlayerAchievements';
 import PlayerActivitiesCommand from './player/PlayerActivities';
 import PlayerBossesCommand from './player/PlayerBosses';
 import PlayerEfficiencyCommand from './player/PlayerEfficiency';
 import PlayerGainedCommand from './player/PlayerGained';
-import PlayerSetUsername from './player/PlayerSetUsername';
 import PlayerSetFlag from './player/PlayerSetFlag';
+import PlayerSetUsername from './player/PlayerSetUsername';
 import PlayerStatsCommand from './player/PlayerStats';
 import PlayerUpdateCommand from './player/UpdatePlayer';
 
 const commands: Command[] = [
   // general commands
   HelpCommand,
+
+  // moderation commands
+  ResetGroupCode,
+  ResetCompetitionCode,
 
   // player commands
   PlayerStatsCommand,

--- a/src/commands/instances/moderation/ResetCompetitionCode.ts
+++ b/src/commands/instances/moderation/ResetCompetitionCode.ts
@@ -21,7 +21,11 @@ class ResetCompetitionCode implements Command {
   }
 
   activated(message: ParsedMessage) {
-    return message.command === 'reset-competition-code' && message.args.length >= 2;
+    return (
+      message.command === 'reset-competition-code' &&
+      message.args.length >= 2 &&
+      message.sourceMessage?.guild?.id === config.discord.guildId
+    );
   }
 
   async execute(message: ParsedMessage) {

--- a/src/commands/instances/moderation/ResetCompetitionCode.ts
+++ b/src/commands/instances/moderation/ResetCompetitionCode.ts
@@ -1,0 +1,74 @@
+import { GuildMember, MessageEmbed } from 'discord.js';
+import { resetCode } from '../../../api/modules/competitions';
+import config from '../../../config';
+import { Command, ParsedMessage } from '../../../types';
+import { hasModeratorRole } from '../../../utils';
+import CommandError from '../../CommandError';
+
+const DM_MESSAGE = (code: string) =>
+  `Hey! Here's your new verification code: \`${code}\`. \nPlease save it somewhere safe and be mindful of who you choose to share it with.`;
+
+const CHAT_MESSAGE = (userId: string) =>
+  `Verification code successfully reset. A DM has been sent to <@${userId}>.`;
+
+class ResetCompetitionCode implements Command {
+  name: string;
+  template: string;
+
+  constructor() {
+    this.name = "Reset a competition's verification code";
+    this.template = '!reset-competition-code {competitionId} {userTag}';
+  }
+
+  activated(message: ParsedMessage) {
+    return message.command === 'reset-competition-code' && message.args.length >= 2;
+  }
+
+  async execute(message: ParsedMessage) {
+    if (!hasModeratorRole(message.sourceMessage.member)) {
+      message.respond('Nice try. This command is reserved for Moderators and Admins.');
+      return;
+    }
+
+    const competitionId = this.getCompetitionId(message);
+    const userId = this.getUserId(message);
+    const user = this.getMember(message, userId);
+
+    if (!competitionId) throw new CommandError('Invalid competition id.');
+    if (!userId) throw new CommandError('Invalid user tag.');
+    if (!user) throw new CommandError('Failed to find user from tag.');
+
+    try {
+      const { newCode } = await resetCode(competitionId);
+
+      // DM the user back with the new verification code
+      await user.send(DM_MESSAGE(newCode));
+
+      // Respond on the WOM discord chat with a success status
+      const response = new MessageEmbed()
+        .setColor(config.visuals.green)
+        .setDescription(CHAT_MESSAGE(userId));
+
+      message.respond(response);
+    } catch (error) {
+      console.log(error);
+      throw new CommandError('Failed to reset competition verification code.');
+    }
+  }
+
+  getCompetitionId(message: ParsedMessage): number | null {
+    const match = message.args.find(a => a !== 'competition' && !isNaN(Number(a)));
+    return match ? parseInt(match, 10) : null;
+  }
+
+  getUserId(message: ParsedMessage): string | undefined {
+    return message.args.find(a => a.startsWith('<@') && a.endsWith('>'))?.replace(/\D/g, '');
+  }
+
+  getMember(message: ParsedMessage, userId: string | undefined): GuildMember | undefined {
+    if (!userId) return undefined;
+    return message.sourceMessage.guild?.members.cache.find(m => m.id === userId);
+  }
+}
+
+export default new ResetCompetitionCode();

--- a/src/commands/instances/moderation/ResetGroupCode.ts
+++ b/src/commands/instances/moderation/ResetGroupCode.ts
@@ -21,7 +21,11 @@ class ResetGroupCode implements Command {
   }
 
   activated(message: ParsedMessage) {
-    return message.command === 'reset-group-code' && message.args.length >= 2;
+    return (
+      message.command === 'reset-group-code' &&
+      message.args.length >= 2 &&
+      message.sourceMessage?.guild?.id === config.discord.guildId
+    );
   }
 
   async execute(message: ParsedMessage) {

--- a/src/commands/instances/moderation/ResetGroupCode.ts
+++ b/src/commands/instances/moderation/ResetGroupCode.ts
@@ -1,0 +1,73 @@
+import { GuildMember, MessageEmbed } from 'discord.js';
+import { resetCode } from '../../../api/modules/groups';
+import config from '../../../config';
+import { Command, ParsedMessage } from '../../../types';
+import { hasModeratorRole } from '../../../utils';
+import CommandError from '../../CommandError';
+
+const DM_MESSAGE = (code: string) =>
+  `Hey! Here's your new verification code: \`${code}\`. \nPlease save it somewhere safe and be mindful of who you choose to share it with.`;
+
+const CHAT_MESSAGE = (userId: string) =>
+  `Verification code successfully reset. A DM has been sent to <@${userId}>.`;
+
+class ResetGroupCode implements Command {
+  name: string;
+  template: string;
+
+  constructor() {
+    this.name = "Reset a group's verification code";
+    this.template = '!reset-group-code {groupId} {userTag}';
+  }
+
+  activated(message: ParsedMessage) {
+    return message.command === 'reset-group-code' && message.args.length >= 2;
+  }
+
+  async execute(message: ParsedMessage) {
+    if (!hasModeratorRole(message.sourceMessage.member)) {
+      message.respond('Nice try. This command is reserved for Moderators and Admins.');
+      return;
+    }
+
+    const groupId = this.getGroupId(message);
+    const userId = this.getUserId(message);
+    const user = this.getMember(message, userId);
+
+    if (!groupId) throw new CommandError('Invalid group id.');
+    if (!userId) throw new CommandError('Invalid user tag.');
+    if (!user) throw new CommandError('Failed to find user from tag.');
+
+    try {
+      const { newCode } = await resetCode(groupId);
+
+      // DM the user back with the new verification code
+      await user.send(DM_MESSAGE(newCode));
+
+      // Respond on the WOM discord chat with a success status
+      const response = new MessageEmbed()
+        .setColor(config.visuals.green)
+        .setDescription(CHAT_MESSAGE(userId));
+
+      message.respond(response);
+    } catch (error) {
+      throw new CommandError('Failed to reset group verification code.');
+    }
+  }
+
+  getGroupId(message: ParsedMessage): number | null {
+    const match = message.args.find(a => a !== 'group' && !isNaN(Number(a)));
+    return match ? parseInt(match, 10) : null;
+  }
+
+  getUserId(message: ParsedMessage): string | undefined {
+    return message.args.find(a => a.startsWith('<@') && a.endsWith('>'))?.replace(/\D/g, '');
+  }
+
+  getMember(message: ParsedMessage, userId: string | undefined): GuildMember | undefined {
+    if (!userId) return undefined;
+    return message.sourceMessage.guild?.members.cache.find(m => m.id === userId);
+  }
+}
+
+export default new ResetGroupCode();

--- a/src/commands/instances/moderation/VerifyGroup.ts
+++ b/src/commands/instances/moderation/VerifyGroup.ts
@@ -1,0 +1,90 @@
+import { GuildMember, MessageEmbed, TextChannel } from 'discord.js';
+import { verify } from '../../../api/modules/groups';
+import { Group } from '../../../api/types';
+import config from '../../../config';
+import { Command, ParsedMessage } from '../../../types';
+import { getEmoji, hasModeratorRole } from '../../../utils';
+import CommandError from '../../CommandError';
+
+const CHAT_MESSAGE = (groupName: string) =>
+  `${getEmoji('success')} \`${groupName}\` has been successfully verified!`;
+
+const LOG_MESSAGE = (groupId: number, groupName: string, userId: string) =>
+  `${groupName} (${groupId}) - <@${userId}>`;
+
+class VerifyGroup implements Command {
+  name: string;
+  template: string;
+
+  constructor() {
+    this.name = 'Set a group as verified.';
+    this.template = '!verify-group {groupId} {userTag}';
+  }
+
+  activated(message: ParsedMessage) {
+    return message.command === 'verify-group' && message.args.length >= 2;
+  }
+
+  async execute(message: ParsedMessage) {
+    if (!hasModeratorRole(message.sourceMessage.member)) {
+      message.respond('Nice try. This command is reserved for Moderators and Admins.');
+      return;
+    }
+
+    const groupId = this.getGroupId(message);
+    const userId = this.getUserId(message);
+    const user = this.getMember(message, userId);
+
+    if (!groupId) throw new CommandError('Invalid group id.');
+    if (!userId) throw new CommandError('Invalid user tag.');
+    if (!user) throw new CommandError('Failed to find user from tag.');
+
+    try {
+      const group = await verify(groupId);
+
+      // Respond on the WOM discord chat with a success status
+      const response = new MessageEmbed()
+        .setColor(config.visuals.green)
+        .setDescription(CHAT_MESSAGE(group.name));
+
+      message.respond(response);
+
+      this.sendConfirmationLog(message, group, userId);
+      this.addRole(user);
+    } catch (error) {
+      console.log(error);
+      throw new CommandError('Failed to reset group verification code.');
+    }
+  }
+
+  addRole(user: GuildMember) {
+    user.roles.add(config.discord.roles.groupLeader).catch(console.log);
+  }
+
+  sendConfirmationLog(message: ParsedMessage, group: Group, userId: string) {
+    const leadersLogChannel = message.sourceMessage.guild?.channels.cache.get(
+      config.discord.channels.leadersLog
+    );
+
+    if (!leadersLogChannel) return;
+    if (!((channel): channel is TextChannel => channel.type === 'text')(leadersLogChannel)) return;
+
+    leadersLogChannel.send(LOG_MESSAGE(group.id, group.name, userId));
+  }
+
+  getGroupId(message: ParsedMessage): number | null {
+    const match = message.args.find(a => a !== 'group' && !isNaN(Number(a)));
+    return match ? parseInt(match, 10) : null;
+  }
+
+  getUserId(message: ParsedMessage): string | undefined {
+    return message.args.find(a => a.startsWith('<@') && a.endsWith('>'))?.replace(/\D/g, '');
+  }
+
+  getMember(message: ParsedMessage, userId: string | undefined): GuildMember | undefined {
+    if (!userId) return undefined;
+    return message.sourceMessage.guild?.members.cache.find(m => m.id === userId);
+  }
+}
+
+export default new VerifyGroup();

--- a/src/commands/instances/moderation/VerifyGroup.ts
+++ b/src/commands/instances/moderation/VerifyGroup.ts
@@ -22,7 +22,11 @@ class VerifyGroup implements Command {
   }
 
   activated(message: ParsedMessage) {
-    return message.command === 'verify-group' && message.args.length >= 2;
+    return (
+      message.command === 'verify-group' &&
+      message.args.length >= 2 &&
+      message.sourceMessage?.guild?.id === config.discord.guildId
+    );
   }
 
   async execute(message: ParsedMessage) {

--- a/src/commands/instances/player/PlayerSetFlag.ts
+++ b/src/commands/instances/player/PlayerSetFlag.ts
@@ -25,8 +25,8 @@ class PlayerSetFlag implements Command {
     const response = { message: '', isError: false };
 
     if (
-      message.sourceMessage?.guild?.id !== config.womGuild.id ||
-      message.sourceMessage?.channel?.id !== config.womGuild.flagChannelId
+      message.sourceMessage?.guild?.id !== config.discord.guildId ||
+      message.sourceMessage?.channel?.id !== config.discord.channels.flags
     ) {
       throw new CommandError(
         'This command only works in the **#change-flag** channel of the official Wise Old Man discord server.\

--- a/src/commands/instances/player/PlayerSetFlag.ts
+++ b/src/commands/instances/player/PlayerSetFlag.ts
@@ -2,7 +2,7 @@ import { MessageEmbed } from 'discord.js';
 import { updateCountry } from '../../../api/modules/players';
 import config from '../../../config';
 import { Command, ParsedMessage } from '../../../types';
-import { getEmoji, countryCodeEmoji, emojiCountryCode } from '../../../utils';
+import { countryCodeEmoji, emojiCountryCode, getEmoji } from '../../../utils';
 import CommandError from '../../CommandError';
 
 class PlayerSetFlag implements Command {
@@ -25,8 +25,8 @@ class PlayerSetFlag implements Command {
     const response = { message: '', isError: false };
 
     if (
-      message.sourceMessage?.guild?.id !== config.womGuildId ||
-      message.sourceMessage?.channel?.id !== config.womFlagChannelId
+      message.sourceMessage?.guild?.id !== config.womGuild.id ||
+      message.sourceMessage?.channel?.id !== config.womGuild.flagChannelId
     ) {
       throw new CommandError(
         'This command only works in the **#change-flag** channel of the official Wise Old Man discord server.\

--- a/src/commands/router.ts
+++ b/src/commands/router.ts
@@ -1,6 +1,6 @@
 import { Message, MessageEmbed } from 'discord.js';
 import config from '../config';
-import { isAdmin, getMissingPermissions } from '../utils';
+import { getMissingPermissions, isAdmin } from '../utils';
 import CommandError from './CommandError';
 import commands from './instances';
 import * as parser from './parser';

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,13 +6,16 @@ export default {
   validPrefixes: ['!', '-', '+', '++', '$'],
   helpCommand: 'wom!help',
   baseAPIUrl: 'https://api.wiseoldman.net',
-  womGuildId: '679454777708380161',
-  womFlagChannelId: '802680940835897384',
   requiredPermissions: ['MANAGE_MESSAGES', 'EMBED_LINKS', 'ATTACH_FILES', 'ADD_REACTIONS'],
   visuals: {
     blue: '#2980b9',
     red: '#cc4242',
     green: '#64d85b',
     orange: '#ecbf54'
+  },
+  womGuild: {
+    id: '679454777708380161',
+    flagChannelId: '802680940835897384',
+    moderatorRoleId: '838198270601723915'
   }
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,9 +13,15 @@ export default {
     green: '#64d85b',
     orange: '#ecbf54'
   },
-  womGuild: {
-    id: '679454777708380161',
-    flagChannelId: '802680940835897384',
-    moderatorRoleId: '838198270601723915'
+  discord: {
+    guildId: '679454777708380161',
+    roles: {
+      moderator: '705821689526747136',
+      groupLeader: '705826389474934845'
+    },
+    channels: {
+      flags: '802680940835897384',
+      leadersLog: '830199626630955039'
+    }
   }
 };

--- a/src/utils/discord.ts
+++ b/src/utils/discord.ts
@@ -7,14 +7,21 @@ import {
   TextChannel
 } from 'discord.js';
 import bot from '../bot';
-import { Emoji } from '../types';
 import config from '../config';
+import { Emoji } from '../types';
 import { getAbbreviation } from './metrics';
 
 export const MAX_FIELD_SIZE = 25;
 
 export function isAdmin(member: GuildMember | null): boolean {
   return member ? member?.hasPermission('ADMINISTRATOR') : false;
+}
+
+export function hasModeratorRole(member: GuildMember | null): boolean {
+  if (!member) return false;
+  if (!member.roles || !member.roles.cache) return false;
+
+  return member.roles.cache.some(r => r.id === config.womGuild.moderatorRoleId);
 }
 
 export function getMissingPermissions(member: GuildMember | null | undefined): string[] | null {

--- a/src/utils/discord.ts
+++ b/src/utils/discord.ts
@@ -21,7 +21,7 @@ export function hasModeratorRole(member: GuildMember | null): boolean {
   if (!member) return false;
   if (!member.roles || !member.roles.cache) return false;
 
-  return member.roles.cache.some(r => r.id === config.womGuild.moderatorRoleId);
+  return member.roles.cache.some(r => r.id === config.discord.roles.moderator);
 }
 
 export function getMissingPermissions(member: GuildMember | null | undefined): string[] | null {


### PR DESCRIPTION
Resolves #85 

Adds a few private commands meant for moderator use in WOM's discord server.

`!verify-group {groupId} {userTag}`
`!reset-group-code {groupId} {userTag}`
`!reset-competition-code {competitionId} {userTag}`