### PR TITLE
Fix (hopefully) broadcast channels' fetching

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -22,6 +22,8 @@ export function init(): Express {
       return res.status(401).json('Wrong API Token.');
     }
 
+    console.log('Event received: ', req.body);
+
     onEventReceived(req.body);
     return res.json('Event received.');
   });

--- a/src/utils/discord.ts
+++ b/src/utils/discord.ts
@@ -47,8 +47,8 @@ export function propagateMessage(message: StringResolvable, channelIds: string[]
     return;
   }
 
-  channelIds.forEach(id => {
-    const channel = bot.client.channels.cache.get(id);
+  channelIds.forEach(async id => {
+    const channel = await bot.client.channels.fetch(id, true);
 
     if (!channel) return;
     if (!((channel): channel is TextChannel => channel.type === 'text')(channel)) return;


### PR DESCRIPTION
My best guess is that some guilds/channels get dropped from the client cache, and then when a broadcast comes in, the server fails to find references to those channels.