### PR TITLE
Ignore capitalization for hiscores metric

### DIFF
--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -172,7 +172,9 @@ export function getMetricName(metric: string): string {
 }
 
 export function getAbbreviation(abbr: string): string {
-  switch (abbr) {
+  const abbreviation = abbr.toLowerCase();
+
+  switch (abbreviation) {
    // Bosses
     case 'sire':
       return 'abyssal_sire';


### PR DESCRIPTION
Accordingly to #109 , the metric argument is case-sensitive. I think the best approach would be to lowercase the argument at `getAbbreviation()`.