### PR TITLE
Remove bot is typing indicator

### DIFF
--- a/src/commands/router.ts
+++ b/src/commands/router.ts
@@ -73,8 +73,6 @@ export async function onInteractionReceived(interaction: Interaction): Promise<v
     // TODO: Show a proper error when guild isn't configured yet
 
     try {
-      interaction.channel?.sendTyping();
-
       await c.execute(interaction);
     } catch (e) {
       // If a command error was thrown during execution, handle the response here.


### PR DESCRIPTION
This is not very relevant anymore since everything is handled by the interactions now. It was also not being stopped properly since we updated to using interactions.