### PR TITLE
Feat/check config channel permissions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-bot",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-bot",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "ISC",
       "dependencies": {
         "@discordjs/builders": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-bot",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A Discord bot for the Wise Old Man projects (https://github.com/wise-old-man/wise-old-man/)",
   "author": "Psikoi",
   "license": "ISC",

--- a/src/commands/router.ts
+++ b/src/commands/router.ts
@@ -74,25 +74,27 @@ export async function onInteractionReceived(interaction: Interaction) {
 
   const commandMonitor = monitoring.trackCommand();
 
+  const commandName = interaction.commandName;
+  const subCommandName = interaction.options.getSubcommand(false);
+
+  const fullCommandName = subCommandName ? `${commandName}:${subCommandName}` : commandName;
+
   try {
-    const { commandName } = interaction;
     const targetCommand = COMMANDS.find(cmd => cmd.slashCommand.name === commandName);
 
     if (!targetCommand) {
       throw new Error(`Error: Command not implemented: ${commandName}`);
     }
 
-    // await interaction.channel?.sendTyping();
     await interaction.deferReply();
-
     await targetCommand.execute(interaction);
 
-    commandMonitor.endTracking(interaction.commandName, 1, interaction.guildId);
+    commandMonitor.endTracking(fullCommandName, 1, interaction.guildId);
   } catch (error) {
     console.log(error);
     Sentry.captureException(error);
     await interaction.followUp({ embeds: [buildErrorEmbed(error)] });
-    commandMonitor.endTracking(interaction.commandName, 0, interaction.guildId);
+    commandMonitor.endTracking(fullCommandName, 0, interaction.guildId);
   }
 }
 


### PR DESCRIPTION
closes #165 

Changes the `/config channel` command to check permissions before saving changes to the configurations.

- It will now first check that the target channel is a valid text channel inside a guild (server)
- Then, check that the target channel is visible (aka it's public or the bot is invited to it)
- Then, check if the channel has all the permissions it needs, otherwise it'll report back what the missing permissions are
- And if nothing else fails, it will send an empty (and temporary) message to the target channel to make sure it can