### PR TITLE
fix: Fix server groupId upsert & handle name change review errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-bot",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-bot",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "license": "ISC",
       "dependencies": {
         "@discordjs/builders": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-bot",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "A Discord bot for the Wise Old Man projects (https://github.com/wise-old-man/wise-old-man/)",
   "author": "Psikoi",
   "license": "ISC",

--- a/src/commands/instances/config/ConfigGroupCommand.ts
+++ b/src/commands/instances/config/ConfigGroupCommand.ts
@@ -1,6 +1,6 @@
 import { CommandInteraction, MessageEmbed } from 'discord.js';
 import config from '../../../config';
-import prisma from '../../../services/prisma';
+import { updateServerGroup } from '../../../services/prisma';
 import womClient from '../../../services/wiseoldman';
 import { Command, CommandConfig, CommandError } from '../../../utils';
 
@@ -36,10 +36,7 @@ class ConfigGroupCommand extends Command {
     });
 
     // Update the server's group ID in the database
-    await prisma.server.update({
-      where: { guildId },
-      data: { groupId }
-    });
+    await updateServerGroup(guildId, groupId);
 
     const response = new MessageEmbed()
       .setColor(config.visuals.green)

--- a/src/services/prisma.ts
+++ b/src/services/prisma.ts
@@ -63,6 +63,22 @@ async function updateBotDefaultChannel(guildId: string, channelId: string) {
   });
 }
 
+/**
+ * Update the server's tracked group.
+ */
+async function updateServerGroup(guildId: string, groupId: number) {
+  const server = await getServer(guildId);
+
+  if (!server) {
+    throw new Error(`Server does not exist for guild id: ${guildId}`);
+  }
+
+  return prisma.server.update({
+    where: { guildId },
+    data: { groupId }
+  });
+}
+
 async function updateNotificationPreferences(guildId: string, type: string, channelId: string | null) {
   return prisma.notificationPreference.upsert({
     where: { guildId_type: { guildId, type } },
@@ -87,6 +103,7 @@ export {
   getUsername,
   getServer,
   getServers,
+  updateServerGroup,
   updateBotDefaultChannel,
   updateNotificationPreferences,
   getNotificationPreferences


### PR DESCRIPTION
fixes #173 

- Fixes the scenario where a user would try to config their server's group before the server is registered on our database
- Handles 500 (Jagex hiscores is unavailable) errors in `/namechange` 
- Handles 504 (request timed out) errors in `/namechange` (some name change approvals can take over 60s if there's a lot of data being transfered over)