### PR TITLE
#164 allow tagging of discord users in username field

### DIFF
--- a/src/commands/instances/player/PlayerAchievementsCommand.ts
+++ b/src/commands/instances/player/PlayerAchievementsCommand.ts
@@ -24,7 +24,7 @@ const CONFIG: CommandConfig = {
     {
       type: 'string',
       name: 'username',
-      description: 'In-game username.'
+      description: 'In-game username or discord tag'
     }
   ]
 };

--- a/src/commands/instances/player/PlayerActivitiesCommand.ts
+++ b/src/commands/instances/player/PlayerActivitiesCommand.ts
@@ -38,7 +38,7 @@ const CONFIG: CommandConfig = {
     {
       type: 'string',
       name: 'username',
-      description: 'In-game username.'
+      description: 'In-game username or discord tag.'
     }
   ]
 };

--- a/src/commands/instances/player/PlayerBossesCommand.ts
+++ b/src/commands/instances/player/PlayerBossesCommand.ts
@@ -40,7 +40,7 @@ const CONFIG: CommandConfig = {
     {
       type: 'string',
       name: 'username',
-      description: 'In-game username.'
+      description: 'In-game username or discord tag.'
     }
   ]
 };

--- a/src/commands/instances/player/PlayerEfficiencyCommand.ts
+++ b/src/commands/instances/player/PlayerEfficiencyCommand.ts
@@ -11,7 +11,7 @@ const CONFIG: CommandConfig = {
     {
       type: 'string',
       name: 'username',
-      description: 'In-game username.'
+      description: 'In-game username or discord tag.'
     }
   ]
 };

--- a/src/commands/instances/player/PlayerGainedCommand.ts
+++ b/src/commands/instances/player/PlayerGainedCommand.ts
@@ -35,7 +35,7 @@ const CONFIG: CommandConfig = {
     {
       type: 'string',
       name: 'username',
-      description: 'In-game username.'
+      description: 'In-game username or discord tag.'
     }
   ]
 };

--- a/src/commands/instances/player/PlayerSetFlagCommand.ts
+++ b/src/commands/instances/player/PlayerSetFlagCommand.ts
@@ -11,7 +11,7 @@ const CONFIG: CommandConfig = {
     {
       type: 'string',
       name: 'username',
-      description: 'In-game username.',
+      description: 'In-game username',
       required: true
     },
     {

--- a/src/commands/instances/player/PlayerStatsCommand.ts
+++ b/src/commands/instances/player/PlayerStatsCommand.ts
@@ -70,7 +70,7 @@ const CONFIG: CommandConfig = {
     {
       type: 'string',
       name: 'username',
-      description: 'In-game username.'
+      description: 'In-game username or discord tag.'
     }
   ]
 };

--- a/src/commands/instances/player/UpdatePlayerCommand.ts
+++ b/src/commands/instances/player/UpdatePlayerCommand.ts
@@ -10,7 +10,7 @@ const CONFIG: CommandConfig = {
     {
       type: 'string',
       name: 'username',
-      description: 'In-game username.'
+      description: 'In-game username or discord tag.'
     }
   ]
 };

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -6,6 +6,8 @@ import {
 import { CommandInteraction } from 'discord.js';
 import { getServer, getUsername } from '../services/prisma';
 
+const DISCORD_TAG_REGEX = /<@!?(\d+)>/;
+
 export class CommandError extends Error {
   tip?: string;
 
@@ -165,9 +167,8 @@ function attachOptions(
 }
 
 export async function getUsernameParam(interaction: CommandInteraction) {
-  const discordTagRegex = /<@!?(\d+)>/;
   const username = interaction.options.getString('username', false);
-  const isDiscordId = username?.match(discordTagRegex);
+  const isDiscordId = username?.match(DISCORD_TAG_REGEX);
 
   if (username && !isDiscordId) return username;
 

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -170,11 +170,11 @@ export async function getUsernameParam(interaction: CommandInteraction) {
   const username = interaction.options.getString('username', false);
   const isDiscordId = username?.match(DISCORD_TAG_REGEX);
 
-  if (username && !isDiscordId) return username;
+  if (username !== null && !isDiscordId) return username;
 
   // if it's a discord id, replace the <@> and pass as the alias id
   const inferredUsername = await getUsername(
-    isDiscordId && username?.length ? username.replace(/[^0-9]/g, '') : interaction.user.id
+    isDiscordId && username !== null ? username.replace(/[^0-9]/g, '') : interaction.user.id
   );
 
   if (!inferredUsername) {

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -165,10 +165,16 @@ function attachOptions(
 }
 
 export async function getUsernameParam(interaction: CommandInteraction) {
+  const discordTagRegex = /<@!?(\d+)>/;
   const username = interaction.options.getString('username', false);
-  if (username) return username;
+  const isDiscordId = username.match(discordTagRegex);
 
-  const inferredUsername = await getUsername(interaction.user.id);
+  if (username && !isDiscordId) return username;
+
+  // if it's a discord id, replace the <@> and pass as the alias id
+  const inferredUsername = await getUsername(
+    isDiscordId && username.length ? username.replace(/[^0-9]/g, '') : interaction.user.id
+  );
 
   if (!inferredUsername) {
     throw new CommandError(

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -167,13 +167,13 @@ function attachOptions(
 export async function getUsernameParam(interaction: CommandInteraction) {
   const discordTagRegex = /<@!?(\d+)>/;
   const username = interaction.options.getString('username', false);
-  const isDiscordId = username.match(discordTagRegex);
+  const isDiscordId = username?.match(discordTagRegex);
 
   if (username && !isDiscordId) return username;
 
   // if it's a discord id, replace the <@> and pass as the alias id
   const inferredUsername = await getUsername(
-    isDiscordId && username.length ? username.replace(/[^0-9]/g, '') : interaction.user.id
+    isDiscordId && username?.length ? username.replace(/[^0-9]/g, '') : interaction.user.id
   );
 
   if (!inferredUsername) {


### PR DESCRIPTION
If a string username is passed, use that
If a discord tag is passed (@ Foo) try and fetch the alias for that discord id and user that If no param is passed, infer the alias for the user that sent the message

Fixes #164 