### PR TITLE
Handle agressive retry in de-ironed "rollback" action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wise-old-man-bot",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wise-old-man-bot",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "license": "ISC",
       "dependencies": {
         "@discordjs/builders": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wise-old-man-bot",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "A Discord bot for the Wise Old Man projects (https://github.com/wise-old-man/wise-old-man/)",
   "author": "Psikoi",
   "license": "ISC",

--- a/src/events/instances/PlayerFlaggedReview.ts
+++ b/src/events/instances/PlayerFlaggedReview.ts
@@ -246,7 +246,7 @@ class PlayerFlaggedReview implements Event {
 
         if (clickedId === `deironed/${uniqueId}`) {
           try {
-            await rollback(player.username, true);
+            await handleRollback(player.username);
             message.setColor(config.visuals.green).setFooter({ text: `De-iron fix by ${username}` });
           } catch (error) {
             message.setColor(config.visuals.red).setFooter({ text: `De-iron fix failed` });
@@ -280,6 +280,21 @@ class PlayerFlaggedReview implements Event {
         }
       });
   }
+}
+
+async function handleRollback(username: string) {
+  // First, try to delete only the snapshots AFTER lastChangedAt, if that fails
+  // try to delete the last snapshot (regardless of lastChangedAt date),
+  // if both of those fail, then there's something wrong, just let it throw
+  try {
+    await rollback(username, true);
+  } catch (error) {
+    if (error.message !== "Failed to delete a player's last snapshots.") {
+      throw error;
+    }
+  }
+
+  await rollback(username, false);
 }
 
 function getLargestSkillChanges(previous: FormattedSnapshot, rejected: FormattedSnapshot) {


### PR DESCRIPTION
When a mod decides that a player is flagged due to a de-iron, it will first try only delete snapshots since "lastChangedAt", and if that fails, it will try to delete the last snapshot, regardless of date.

These two attempts should handle most of the de-iron cases.