### PR TITLE
Correctly check requiresAdmin for sub commands

### DIFF
--- a/src/commands/router.ts
+++ b/src/commands/router.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/node';
 import { GuildMember, Interaction, MessageEmbed } from 'discord.js';
 import config from '../config';
 import monitoring from '../utils/monitoring';
-import { BaseCommand, CommandError, isAdmin } from '../utils';
+import { BaseCommand, CommandError, isAdmin, requiresAdminPermissions } from '../utils';
 import {
   getCountryOptions,
   getHelpCategoryOptions,
@@ -88,10 +88,11 @@ export async function onInteractionReceived(interaction: Interaction) {
 
     await interaction.deferReply();
 
-    if (targetCommand.requiresAdmin && !isAdmin(interaction.member as GuildMember)) {
-      const error = new CommandError('That command requires Admin permissions.');
-      await interaction.followUp({ embeds: [buildErrorEmbed(error)] });
-      return;
+    if (
+      requiresAdminPermissions(targetCommand, subCommandName) &&
+      !isAdmin(interaction.member as GuildMember)
+    ) {
+      throw new CommandError('That command requires Admin permissions.');
     }
 
     await targetCommand.execute(interaction);

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -209,3 +209,14 @@ export async function getLinkedGroupId(interaction: CommandInteraction) {
 
   return groupId;
 }
+
+export function requiresAdminPermissions(command: BaseCommand, subCommandName: string | null): boolean {
+  if (!(command instanceof AggregateCommand)) {
+    return !!command.requiresAdmin;
+  }
+
+  return (
+    !!subCommandName &&
+    !!command.subCommands.find(s => s.slashCommand.name === subCommandName)?.requiresAdmin
+  );
+}


### PR DESCRIPTION
~~Since `targetCommand` is a `baseCommand` in router, `targetCommand.requiresAdmin` always returns `undefined` if it is not set at the root command. This causes the issue where commands that require admin permissions still run even when the user doesn't have them.~~

~~Alternatively we can make router check the sub commands individually for `requiresAdmin`. This pr sets admin requirement at the root command for the config commands since there are only two config commands and both require admin permissions.~~

~~This would need to change if we add more config commands where some require admin and some not.~~