### PR TITLE
Make group id when configuring group required

### DIFF
--- a/src/commands/instances/config/ConfigGroupCommand.ts
+++ b/src/commands/instances/config/ConfigGroupCommand.ts
@@ -11,7 +11,8 @@ const CONFIG: CommandConfig = {
     {
       type: 'integer',
       name: 'group_id',
-      description: 'The group ID to link to the server.'
+      description: 'The group ID to link to the server.',
+      required: true
     }
   ]
 };


### PR DESCRIPTION
Must have been lost in translation somewhere. We can't configure a group without a group id.