### PR TITLE
[bot] Reduce player object type in group activity events

### DIFF
--- a/src/events/instances/MembersJoined.ts
+++ b/src/events/instances/MembersJoined.ts
@@ -8,7 +8,7 @@ interface MembersJoinedData {
   groupId: number;
   members: {
     role: GroupRole;
-    player: Player;
+    player: Pick<Player, 'displayName'>;
   }[];
 }
 
@@ -43,7 +43,9 @@ function buildMessage(data: MembersJoinedData) {
   }
 
   if (members.length > 10) {
-    content += `\n[+${members.length - 10} more changes](https://wiseoldman.net/groups/${groupId}?dialog=group-activity)`;
+    content += `\n[+${
+      members.length - 10
+    } more changes](https://wiseoldman.net/groups/${groupId}?dialog=group-activity)`;
   }
 
   const title = `🎉 ${members.length} New group ${members.length === 1 ? 'member' : 'members'} joined`;

--- a/src/events/instances/MembersLeft.ts
+++ b/src/events/instances/MembersLeft.ts
@@ -6,7 +6,7 @@ import { encodeURL, propagateMessage, NotificationType } from '../../utils';
 
 interface MembersLeftData {
   groupId: number;
-  players: Player[];
+  players: Pick<Player, 'displayName'>[];
 }
 
 class MembersLeft implements Event {

--- a/src/events/instances/MembersRolesChanged.ts
+++ b/src/events/instances/MembersRolesChanged.ts
@@ -8,7 +8,7 @@ interface MemberActivity {
   members: {
     role: GroupRole;
     previousRole: GroupRole;
-    player: Player;
+    player: Pick<Player, 'displayName'>;
   }[];
 }
 
@@ -47,7 +47,9 @@ function buildMessage(data: MemberActivity) {
   }
 
   if (members.length > 10) {
-    content += `\n[+${members.length - 10} more changes](https://wiseoldman.net/groups/${groupId}?dialog=group-activity)`;
+    content += `\n[+${
+      members.length - 10
+    } more changes](https://wiseoldman.net/groups/${groupId}?dialog=group-activity)`;
   }
 
   const title = `${members.length} Member ${members.length === 1 ? 'role' : 'roles'} changed`;


### PR DESCRIPTION
Noticed some discord bot events fail to send with the error code "413 Content Too Large", so i'll be sending just partial player objects as the full versions can cause these issues on large group changes.

To prepare for this, the bot needs to stop expecting full player objects.