### PR TITLE
Fix commands failing due to pagination

### DIFF
--- a/src/commands/instances/group/GroupGainedCommand.ts
+++ b/src/commands/instances/group/GroupGainedCommand.ts
@@ -10,6 +10,7 @@ import { ApplicationCommandOptionType, ChatInputCommandInteraction, EmbedBuilder
 import config from '../../../config';
 import womClient, { parseMetricAbbreviation } from '../../../services/wiseoldman';
 import { bold, Command, CommandConfig, CommandError, getEmoji, getLinkedGroupId } from '../../../utils';
+import { createPaginatedEmbed, RESULTS_PER_PAGE } from '../../pagination';
 
 const CONFIG: CommandConfig = {
   name: 'gained',
@@ -53,9 +54,7 @@ class GroupGainedCommand extends Command {
       throw new CommandError(`${e.message}`);
     });
 
-    const gainedList = gained
-      .map((g, i) => `${i + 1}. ${bold(g.player.displayName)} - ${formatNumber(g.data.gained, true)}`)
-      .join('\n');
+    const pageCount = Math.min(25, Math.ceil(gained.length / RESULTS_PER_PAGE));
 
     const urlPeriod =
       period in PeriodProps
@@ -64,14 +63,26 @@ class GroupGainedCommand extends Command {
             Date.now() - parsePeriodExpression(period)!.durationMs
           ).toISOString()}&endDate=${new Date().toISOString()}`;
 
-    const response = new EmbedBuilder()
+    const embedTemplate = new EmbedBuilder()
       .setColor(config.visuals.blue)
       .setTitle(`${getEmoji(metric)} ${group.name} ${MetricProps[metric].name} gains (${period})`)
-      .setURL(`https://wiseoldman.net/groups/${groupId}/gained?${urlPeriod}&metric=${metric}`)
-      .setFooter({ text: `Tip: Try /group gained metric: zulrah period: day` })
-      .setDescription(gainedList);
+      .setURL(`https://wiseoldman.net/groups/${groupId}/gained?${urlPeriod}&metric=${metric}`);
 
-    await interaction.editReply({ embeds: [response] });
+    const paginatedMessage = createPaginatedEmbed(embedTemplate, 120_000);
+
+    for (let i = 0; i < pageCount; i++) {
+      const gainedList = gained
+        .slice(i * RESULTS_PER_PAGE, i * RESULTS_PER_PAGE + RESULTS_PER_PAGE)
+        .map(
+          (g, idx) =>
+            `${i * RESULTS_PER_PAGE + idx + 1}. ${bold(g.player.displayName)} - ${formatNumber(g.data.gained, true)}`
+        )
+        .join('\n');
+
+      paginatedMessage.addPageEmbed(new EmbedBuilder().setDescription(gainedList));
+    }
+
+    paginatedMessage.run(interaction);
   }
 }
 

--- a/src/commands/instances/group/GroupHiscoresCommand.ts
+++ b/src/commands/instances/group/GroupHiscoresCommand.ts
@@ -3,6 +3,7 @@ import { ApplicationCommandOptionType, ChatInputCommandInteraction, EmbedBuilder
 import config from '../../../config';
 import womClient, { parseMetricAbbreviation } from '../../../services/wiseoldman';
 import { bold, Command, CommandConfig, CommandError, getEmoji, getLinkedGroupId } from '../../../utils';
+import { createPaginatedEmbed, RESULTS_PER_PAGE } from '../../pagination';
 
 const CONFIG: CommandConfig = {
   name: 'hiscores',
@@ -35,18 +36,27 @@ class GroupHiscoresCommand extends Command {
 
     const hiscores = await womClient.groups.getGroupHiscores(groupId, metric);
 
-    const hiscoresList = hiscores
-      .map((g, i) => `${i + 1}. ${bold(g.player.displayName)} - ${getValue(g)}`)
-      .join('\n');
+    const pageCount = Math.min(25, Math.ceil(hiscores.length / RESULTS_PER_PAGE));
 
-    const response = new EmbedBuilder()
+    const embedTemplate = new EmbedBuilder()
       .setColor(config.visuals.blue)
       .setTitle(`${getEmoji(metric)} ${group.name} ${MetricProps[metric].name} hiscores`)
-      .setDescription(hiscoresList)
-      .setURL(`https://wiseoldman.net/groups/${groupId}/hiscores?metric=${metric}`)
-      .setFooter({ text: `Tip: Try /group hiscores metric: zulrah` });
+      .setURL(`https://wiseoldman.net/groups/${groupId}/hiscores?metric=${metric}`);
 
-    await interaction.editReply({ embeds: [response] });
+    const paginatedMessage = createPaginatedEmbed(embedTemplate, 120_000);
+
+    for (let i = 0; i < pageCount; i++) {
+      const hiscoresList = hiscores
+        .slice(i * RESULTS_PER_PAGE, i * RESULTS_PER_PAGE + RESULTS_PER_PAGE)
+        .map(
+          (g, idx) => `${i * RESULTS_PER_PAGE + idx + 1}. ${bold(g.player.displayName)} - ${getValue(g)}`
+        )
+        .join('\n');
+
+      paginatedMessage.addPageEmbed(new EmbedBuilder().setDescription(hiscoresList));
+    }
+
+    paginatedMessage.run(interaction);
   }
 }
 

--- a/src/commands/instances/group/GroupMembersCommand.ts
+++ b/src/commands/instances/group/GroupMembersCommand.ts
@@ -2,9 +2,7 @@ import { ChatInputCommandInteraction, EmbedBuilder } from 'discord.js';
 import womClient from '../../../services/wiseoldman';
 import config from '../../../config';
 import { CommandConfig, Command, getLinkedGroupId, CommandError, bold } from '../../../utils';
-import { createPaginatedEmbed } from '../../../commands/pagination';
-
-const RESULTS_PER_PAGE = 20;
+import { createPaginatedEmbed, RESULTS_PER_PAGE } from '../../../commands/pagination';
 
 const CONFIG: CommandConfig = {
   name: 'members',

--- a/src/commands/pagination.ts
+++ b/src/commands/pagination.ts
@@ -1,6 +1,8 @@
 import { PaginatedMessage } from '@sapphire/discord.js-utilities';
 import { ButtonStyle, ComponentType, EmbedBuilder } from 'discord.js';
 
+export const RESULTS_PER_PAGE = 20;
+
 const PAGINATION_BUTTONS = {
   NEXT: {
     customId: 'CustomNextAction',


### PR DESCRIPTION
Fixes the `group hiscores` and `group gained` commands failing due to default pagination being removed for these endpoints in the API. It also paginates the results in the discord embed.